### PR TITLE
Improved ghdl Makefile

### DIFF
--- a/.github/workflows/ubuntu-ghdl.yml
+++ b/.github/workflows/ubuntu-ghdl.yml
@@ -1,0 +1,17 @@
+name: Ubuntu ghdl
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install packages
+      run: sudo apt update && sudo apt install ghdl ghdl-llvm ghdl-gcc make
+    - name: Show ghdl version information
+      run: ghdl --version
+    - name: Synthesize and Elaborate
+      run: mkdir build && cd build && make -f ../Makefile synthesis && make -f ../Makefile elaborate
+    - name: Run test bench
+      run: cd build && make -f ../Makefile run

--- a/Makefile
+++ b/Makefile
@@ -1,70 +1,70 @@
-GHDLFLAGS=-fsynopsys
+GHDLFLAGS=-v -fsynopsys -frelaxed-rules -Wl,-Wl,--gc-sections -fexplicit --ieee=synopsys --syn-binding --vital-checks --std=93 -frelaxed
 synthesis:
-	ghdl -a ${GHDLFLAGS} ../constants.pkg.vhd
-	ghdl -a ${GHDLFLAGS} ../data_type.pkg.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/FIFO_buffer.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/comparator.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/sort_bram.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/block_ram.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/small_random_weights.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/FIFO_buffer.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/mod3_freeze.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/modq_freeze.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/SDP_dist_RAM.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/small_random_weights.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/sort_bram.vhd
-	ghdl -a ${GHDLFLAGS} ../misc/stack_memory.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/modq_reciprocal.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/bram_r3_reciprocal.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/bram_rq_reciprocal_3.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/r3_reciprocal.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/modq_minus_product.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/modq_reciprocal.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/rq_reciprocal_3.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/key_generation.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/encode_R3.vhd 
-	ghdl -a ${GHDLFLAGS} ../keygen/key_gen_wrapper.vhd
-	ghdl -a ${GHDLFLAGS} ../keygen/rq_reciprocal_3.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/division_32_by_const.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/div_mod_pipeline.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/decode_R3.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/decode_Rq.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/division_32_by_const.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/div_mod_pipeline.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/encode_R3.vhd
-	ghdl -a ${GHDLFLAGS} ../encoding/encode_Rq.vhd
-	ghdl -a ${GHDLFLAGS} ../multiplication/rq_mult_generic_3bit.vhd
-	ghdl -a ${GHDLFLAGS} ../multiplication/rq_mult_generic_4bit.vhd
-	ghdl -a ${GHDLFLAGS} ../multiplication/rq_mult_generic.vhd
-	ghdl -a ${GHDLFLAGS} ../multiplication/rq_mult_generic_x3_3bit.vhd
-	ghdl -a ${GHDLFLAGS} ../multiplication/rq_mult_generic_x3.vhd
-	ghdl -a ${GHDLFLAGS} ../multiplication/rq_mult_karatsuba_2bit_2nd_layer.vhd
-	ghdl -a ${GHDLFLAGS} ../multiplication/rq_mult_karatsuba_3bit_2nd_layer.vhd
-	ghdl -a ${GHDLFLAGS} ../multiplication/rq_mult_karatsuba.vhd
-	ghdl -a ${GHDLFLAGS} ../encapsulation/key_encapsulation.vhd
-	ghdl -a ${GHDLFLAGS} ../encapsulation/key_encap_wrapper.vhd
-	ghdl -a ${GHDLFLAGS} ../decapsulation/rq_mult3.vhd
-	ghdl -a ${GHDLFLAGS} ../decapsulation/calc_weight.vhd
-	ghdl -a ${GHDLFLAGS} ../decapsulation/key_decapsulation.vhd
-	ghdl -a ${GHDLFLAGS} ../decapsulation/key_decap_wrapper.vhd
-	ghdl -a ${GHDLFLAGS} ../sha_512/sha_512_pkg.vhdl
-	ghdl -a ${GHDLFLAGS} ../sha_512/ROM.vhd
-	ghdl -a ${GHDLFLAGS} ../sha_512/sha_512_core.vhdl
-	ghdl -a ${GHDLFLAGS} ../sha_512/sha_512_wrapper.vhd
-	ghdl -a ${GHDLFLAGS} ../ntru_prime_top.vhd
-	ghdl -a ${GHDLFLAGS} ../tb/tb_ntru_prime_top.vhd
+	ghdl -a ${GHDLFLAGS} \
+	 ../constants.pkg.vhd \
+	 ../data_type.pkg.vhd \
+	 ../misc/block_ram.vhd \
+	 ../misc/stack_memory.vhd \
+	 ../misc/FIFO_buffer.vhd \
+	 ../misc/comparator.vhd \
+	 ../misc/sort_bram.vhd \
+	 ../misc/small_random_weights.vhd \
+	 ../misc/mod3_freeze.vhd \
+	 ../misc/modq_freeze.vhd \
+	 ../misc/SDP_dist_RAM.vhd \
+	 ../misc/sort_bram.vhd \
+	 ../misc/small_random_weights.vhd \
+	 ../encoding/division_32_by_const.vhd \
+	 ../encoding/div_mod_pipeline.vhd \
+	 ../encoding/encode_R3.vhd \
+	 ../encoding/division_32_by_const.vhd \
+	 ../encoding/div_mod_pipeline.vhd \
+ 	 ../encoding/decode_Rq.vhd \
+	 ../encoding/decode_R3.vhd \
+	 ../encoding/encode_R3.vhd \
+	 ../encoding/encode_Rq.vhd \
+	 ../multiplication/rq_mult_generic_3bit.vhd \
+	 ../multiplication/rq_mult_generic_4bit.vhd \
+	 ../multiplication/rq_mult_generic.vhd \
+	 ../multiplication/rq_mult_generic_x3_3bit.vhd \
+	 ../multiplication/rq_mult_generic_x3.vhd \
+	 ../multiplication/rq_mult_karatsuba_2bit_2nd_layer.vhd \
+	 ../multiplication/rq_mult_karatsuba_3bit_2nd_layer.vhd \
+	 ../multiplication/rq_mult_karatsuba.vhd \
+	 ../encapsulation/key_encapsulation.vhd \
+	 ../encapsulation/key_encap_wrapper.vhd \
+	 ../decapsulation/rq_mult3.vhd \
+	 ../decapsulation/calc_weight.vhd \
+	 ../decapsulation/key_decapsulation.vhd \
+	 ../decapsulation/key_decap_wrapper.vhd \
+	 ../sha_512/sha_512_pkg.vhdl \
+	 ../sha_512/ROM.vhd \
+	 ../sha_512/sha_512_core.vhdl \
+	 ../sha_512/sha_512_wrapper.vhd \
+	 ../keygen/bram_r3_reciprocal.vhd \
+	 ../keygen/bram_rq_reciprocal_3.vhd \
+	 ../keygen/modq_reciprocal.vhd \
+	 ../keygen/r3_reciprocal.vhd \
+	 ../keygen/modq_minus_product.vhd \
+	 ../keygen/modq_reciprocal.vhd \
+	 ../keygen/rq_reciprocal_3.vhd \
+	 ../keygen/key_generation.vhd \
+	 ../keygen/key_gen_wrapper.vhd \
+	 ../ntru_prime_top.vhd \
+	 ../tb/tb_ntru_prime_top.vhd
+
 
 elaborate:
 	ghdl -e ${GHDLFLAGS} FIFO_buffer
 	ghdl -e ${GHDLFLAGS} comparator
 	ghdl -e ${GHDLFLAGS} sort_bram
+	ghdl -e ${GHDLFLAGS} small_random_weights
 	ghdl -e ${GHDLFLAGS} block_ram
-	#ghdl -e ${GHDLFLAGS} small_random_weights
+	ghdl -e ${GHDLFLAGS} K_ROM
 	ghdl -e ${GHDLFLAGS} FIFO_buffer
 	ghdl -e ${GHDLFLAGS} mod3_freeze
 	ghdl -e ${GHDLFLAGS} modq_freeze
 	ghdl -e ${GHDLFLAGS} SDP_dist_RAM
-	#ghdl -e ${GHDLFLAGS} small_random_weights
 	ghdl -e ${GHDLFLAGS} stack_memory
 	ghdl -e ${GHDLFLAGS} modq_reciprocal
 	ghdl -e ${GHDLFLAGS} bram_r3_reciprocal
@@ -73,14 +73,13 @@ elaborate:
 	ghdl -e ${GHDLFLAGS} modq_minus_product
 	ghdl -e ${GHDLFLAGS} modq_reciprocal
 	ghdl -e ${GHDLFLAGS} rq_reciprocal_3
-#	ghdl -e ${GHDLFLAGS} key_generation
 	ghdl -e ${GHDLFLAGS} encode_R3
-	#ghdl -e ${GHDLFLAGS} key_gen_wrapper
+	ghdl -e ${GHDLFLAGS} key_gen_wrapper
 	ghdl -e ${GHDLFLAGS} rq_reciprocal_3
 	ghdl -e ${GHDLFLAGS} division_32_by_const
+	ghdl -e ${GHDLFLAGS} decode_Rq
 	ghdl -e ${GHDLFLAGS} div_mod_pipeline
 	ghdl -e ${GHDLFLAGS} decode_R3
-	#ghdl -e ${GHDLFLAGS} decode_Rq
 	ghdl -e ${GHDLFLAGS} division_32_by_const
 	ghdl -e ${GHDLFLAGS} div_mod_pipeline
 	ghdl -e ${GHDLFLAGS} encode_R3
@@ -92,19 +91,19 @@ elaborate:
 	ghdl -e ${GHDLFLAGS} rq_mult_generic_x3
 	ghdl -e ${GHDLFLAGS} rq_mult_karatsuba_2bit_2nd_layer
 	ghdl -e ${GHDLFLAGS} rq_mult_karatsuba_3bit_2nd_layer
-	#ghdl -e ${GHDLFLAGS} rq_mult_karatsuba
+	ghdl -e ${GHDLFLAGS} rq_mult_karatsuba_2bit
 	ghdl -e ${GHDLFLAGS} key_encapsulation
 	ghdl -e ${GHDLFLAGS} key_encap_wrapper
 	ghdl -e ${GHDLFLAGS} rq_mult3
 	ghdl -e ${GHDLFLAGS} calc_weight
 	ghdl -e ${GHDLFLAGS} key_decapsulation
 	ghdl -e ${GHDLFLAGS} key_decap_wrapper
-	#ghdl -e ${GHDLFLAGS} sha_512_pkg
-	#ghdl -e ${GHDLFLAGS} ROM
-	#ghdl -e ${GHDLFLAGS} sha_512_core
-	#ghdl -e ${GHDLFLAGS} sha_512_wrapper
+	ghdl -e ${GHDLFLAGS} key_generation
+	ghdl -e ${GHDLFLAGS} K_ROM
+	ghdl -e ${GHDLFLAGS} sha_512_core
+	ghdl -e ${GHDLFLAGS} sha_512_wrapper
+	ghdl -e ${GHDLFLAGS} ntru_prime_top
 	ghdl -e ${GHDLFLAGS} tb_ntru_prime_top
-	#ghdl -e ${GHDLFLAGS} ntru_prime_top
 
 clean:
 	-rm *.o

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,58 @@ synthesis:
 	ghdl -a ${GHDLFLAGS} ../ntru_prime_top.vhd
 	ghdl -a ${GHDLFLAGS} ../tb/tb_ntru_prime_top.vhd
 
+elaborate:
+	ghdl -e ${GHDLFLAGS} FIFO_buffer
+	ghdl -e ${GHDLFLAGS} comparator
+	ghdl -e ${GHDLFLAGS} sort_bram
+	ghdl -e ${GHDLFLAGS} block_ram
+	#ghdl -e ${GHDLFLAGS} small_random_weights
+	ghdl -e ${GHDLFLAGS} FIFO_buffer
+	ghdl -e ${GHDLFLAGS} mod3_freeze
+	ghdl -e ${GHDLFLAGS} modq_freeze
+	ghdl -e ${GHDLFLAGS} SDP_dist_RAM
+	#ghdl -e ${GHDLFLAGS} small_random_weights
+	ghdl -e ${GHDLFLAGS} stack_memory
+	ghdl -e ${GHDLFLAGS} modq_reciprocal
+	ghdl -e ${GHDLFLAGS} bram_r3_reciprocal
+	ghdl -e ${GHDLFLAGS} bram_rq_reciprocal_3
+	ghdl -e ${GHDLFLAGS} r3_reciprocal
+	ghdl -e ${GHDLFLAGS} modq_minus_product
+	ghdl -e ${GHDLFLAGS} modq_reciprocal
+	ghdl -e ${GHDLFLAGS} rq_reciprocal_3
+#	ghdl -e ${GHDLFLAGS} key_generation
+	ghdl -e ${GHDLFLAGS} encode_R3
+	#ghdl -e ${GHDLFLAGS} key_gen_wrapper
+	ghdl -e ${GHDLFLAGS} rq_reciprocal_3
+	ghdl -e ${GHDLFLAGS} division_32_by_const
+	ghdl -e ${GHDLFLAGS} div_mod_pipeline
+	ghdl -e ${GHDLFLAGS} decode_R3
+	#ghdl -e ${GHDLFLAGS} decode_Rq
+	ghdl -e ${GHDLFLAGS} division_32_by_const
+	ghdl -e ${GHDLFLAGS} div_mod_pipeline
+	ghdl -e ${GHDLFLAGS} encode_R3
+	ghdl -e ${GHDLFLAGS} encode_Rq
+	ghdl -e ${GHDLFLAGS} rq_mult_generic_3bit
+	ghdl -e ${GHDLFLAGS} rq_mult_generic_4bit
+	ghdl -e ${GHDLFLAGS} rq_mult_generic
+	ghdl -e ${GHDLFLAGS} rq_mult_generic_x3_3bit
+	ghdl -e ${GHDLFLAGS} rq_mult_generic_x3
+	ghdl -e ${GHDLFLAGS} rq_mult_karatsuba_2bit_2nd_layer
+	ghdl -e ${GHDLFLAGS} rq_mult_karatsuba_3bit_2nd_layer
+	#ghdl -e ${GHDLFLAGS} rq_mult_karatsuba
+	ghdl -e ${GHDLFLAGS} key_encapsulation
+	ghdl -e ${GHDLFLAGS} key_encap_wrapper
+	ghdl -e ${GHDLFLAGS} rq_mult3
+	ghdl -e ${GHDLFLAGS} calc_weight
+	ghdl -e ${GHDLFLAGS} key_decapsulation
+	ghdl -e ${GHDLFLAGS} key_decap_wrapper
+	#ghdl -e ${GHDLFLAGS} sha_512_pkg
+	#ghdl -e ${GHDLFLAGS} ROM
+	#ghdl -e ${GHDLFLAGS} sha_512_core
+	#ghdl -e ${GHDLFLAGS} sha_512_wrapper
+	ghdl -e ${GHDLFLAGS} tb_ntru_prime_top
+	#ghdl -e ${GHDLFLAGS} ntru_prime_top
+
 clean:
 	-rm *.o
 	-rm *.cf

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ elaborate:
 	ghdl -e ${GHDLFLAGS} ntru_prime_top
 	ghdl -e ${GHDLFLAGS} tb_ntru_prime_top
 
+run:
+	ghdl -r ${GHDLFLAGS} tb_ntru_prime_top \
+		--vcd=tb_ntru_prime_top.vcd --wave=tb_ntru_prime_top.ghw
 clean:
 	-rm *.o
 	-rm *.cf
+	-rm *.vcd *.ghw

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GHDLFLAGS=-v -fsynopsys -frelaxed-rules -Wl,-Wl,--gc-sections -fexplicit --ieee=synopsys --syn-binding --vital-checks --std=93 -frelaxed
+GHDLFLAGS=-v -fsynopsys -frelaxed-rules -fexplicit --ieee=synopsys --syn-binding --vital-checks --std=93 -frelaxed
 synthesis:
 	ghdl -a ${GHDLFLAGS} \
 	 ../constants.pkg.vhd \

--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ The folders `encapsulation`, `decapsulation`, `keygen`, `multiplication`, and `e
 
 ## Compatibility
 
-This software was originally build with the non-free Vivado `v2018.3.1` tool chain using the `93` standard.
+This software was originally build with the non-free Vivado `v2018.3.1` tool
+chain using the `93` standard.
 
 ### Free Software support
 
-Experimental support for `synthesis`, `elaborate`, and `run` with `ghdl` is provided using the `Makefile`:
+Experimental support for `synthesis`, `elaborate`, and `run` with `ghdl` is
+provided using the `Makefile`:
 ```
 mkdir build && cd build
 make -f ../Makefile synthesis
@@ -53,4 +55,11 @@ make -f ../Makefile elaborate
 make -f ../Makefile run
 ```
 
-Using `ghdl` version `4.0.0` or `ghdl` from `git tip` with `llvm` should be functional.
+#### Supported `ghdl` configurations
+
+The `ghdl` build process is flexible and may be used with `mcode`, `gcc`, and
+`llvm`. Tested configurations include `ghdl` version `4.0.0` or `ghdl` from
+`git tip` with `llvm`, `ghdl` version `2.0.0` with `mcode`, and `ghdl` version
+`1.0.0` with the `gcc` backend. The latter is used for continuous integration
+using binary packages available on Ubuntu.
+

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 
 This is a constant time hardware implementation of round 3 Streamlined NTRU Prime. This is the code from the paper https://eprint.iacr.org/2020/1067.
 
-The parameter sets sntrup653, sntrup761 and sntrup857 are currently supported, and can be selected with the constant "use_parameter_set" in the file constants.pkg.vhd.
+The parameter sets `sntrup653`, `sntrup761` and `sntrup857` are currently supported, and can be selected with the constant `use_parameter_set` in the file `constants.pkg.vhd`.
 
+## Performance
 
 Since the paper was published, the code was improved, leading to a reduction of FPGA resources.
 
-The following table contains the performance numbers for the parameter set sntrup761:
+The following table contains the performance numbers for the parameter set `sntrup761`:
 
 | Operation       | Cycle Count  | @ 271.6 MHz    |
 | :-------------- | :----------: | :----------: | 
@@ -26,18 +27,30 @@ The following table contains the resources utilization:
 |  sntrup761 - Only Encap     | 844          | 4570         | 2843         | 7.5          | 8            |
 |  sntrup761 - Only Decap     | 902          | 5117         | 2958         | 7            | 8            |
 
-The top module is ntru_prime_top, the corrosponding testbench is tb_ntru_prime_top.
+## Implementation details
 
-The testbench is in the folder tb. The testbench uses stimulus data gathered from the KAT from the NIST submission of Streamlined NTRU Prime (https://ntruprime.cr.yp.to/nist.html). Data for 50 KAT for the three parameter sets are in folder tb\tb_stimulus\, tb_ntru_prime_top will automatically select the correct test data.
+The top module is `ntru_prime_top`, the corrosponding testbench is `tb_ntru_prime_top`.
+
+The testbench is in the folder `tb`. The testbench uses stimulus data gathered from the KAT from the NIST submission of Streamlined NTRU Prime (https://ntruprime.cr.yp.to/nist.html). Data for 50 KAT for the three parameter sets are in folder `tb\tb_stimulus\*`, `tb_ntru_prime_top` will automatically select the correct test data.
 
 The folder sha-512 contains the implementation of the hash function from https://github.com/dsaves/SHA-512, as well as the wrapper used to integrate it into my implementation.
 
-The folder misc contains some miscellaneous items, such as block ram and stack memory, that are need across the design.
+The folder `misc/*` contains some miscellaneous items, such as block ram and stack memory, that are needed across the design.
 
-The folders encapsulation, decapsulation, keygen, multiplication and encoding contain the respective vhdl files for that operation.
+The folders `encapsulation`, `decapsulation`, `keygen`, `multiplication`, and `encoding` contain the respective vhdl files for that operation.
 
-Experimental support for synthesis with `ghdl` is present in the `Makefile`:
+## Compatibility
+
+This software was originally build with the non-free Vivado `v2018.3.1` tool chain using the `93` standard.
+
+### Free Software support
+
+Experimental support for `synthesis`, `elaborate`, and `run` with `ghdl` is provided using the `Makefile`:
 ```
 mkdir build && cd build
 make -f ../Makefile synthesis
+make -f ../Makefile elaborate
+make -f ../Makefile run
 ```
+
+Using `ghdl` version `4.0.0` or `ghdl` from `git tip` with `llvm` should be functional.

--- a/sha_512/ROM.vhd
+++ b/sha_512/ROM.vhd
@@ -7,7 +7,7 @@ use work.sha_512_pkg.all;
 entity K_ROM is
 	port(
 		clock    : in  std_logic;
-		address  : in  integer range 0 to 79;
+		address  : in  integer range 0 to 80;
 		data_out : out STD_LOGIC_VECTOR(WORD_SIZE - 1 downto 0)
 	);
 end entity K_ROM;

--- a/sha_512/sha_512_wrapper.vhd
+++ b/sha_512/sha_512_wrapper.vhd
@@ -55,7 +55,7 @@ architecture RTL of sha_512_wrapper is
 	signal message_byte_valid_pipe : std_logic;
 
 	signal sha_512_data_valid : std_logic;
-	signal sha_512_n_blocks   : natural;
+	signal sha_512_n_blocks   : natural range 0 to 16;
 	--signal sha_512_msg_block_in : std_logic_vector(0 to 1023);
 	signal sha_512_ready      : std_logic;
 	signal sha_512_data_out   : std_logic_vector(63 downto 0);


### PR DESCRIPTION
The `Makefile` now has four targets for `ghdl` based development workflows: 
- `synthesis`
- `elaborate`
- `run`
- `clean`

The `run` target uses the test bench which fails:
```
ghdl -r -v -fsynopsys -frelaxed-rules -Wl,-Wl,--gc-sections -fexplicit --ieee=synopsys --syn-binding --vital-checks --std=93 -frelaxed tb_ntru_prime_top \
	--vcd=tb_ntru_prime_top.vcd --wave=tb_ntru_prime_top.ghw
./tb_ntru_prime_top --vcd=tb_ntru_prime_top.vcd --wave=tb_ntru_prime_top.ghw
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 3 i=1
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 9 i=2
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 27 i=3
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 81 i=4
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 243 i=5
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 729 i=6
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 2187 i=7
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 1970 i=8
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= 1319 i=9
../keygen/rq_reciprocal_3.vhd:36:25:@0ms:(report note): ai= -634 i=10

...

../../src/ieee/v93/numeric_std-body.vhdl:1278:7:@0ms:(assertion warning): NUMERIC_STD."<": metavalue detected, returning FALSE
../../src/ieee/v93/numeric_std-body.vhdl:1278:7:@0ms:(assertion warning): NUMERIC_STD."<": metavalue detected, returning FALSE
../../src/ieee/v93/numeric_std-body.vhdl:1157:7:@0ms:(assertion warning): NUMERIC_STD."<": metavalue detected, returning FALSE
../../src/ieee/v93/numeric_std-body.vhdl:1157:7:@0ms:(assertion warning): NUMERIC_STD."<": metavalue detected, returning FALSE
./tb_ntru_prime_top:error: bound check failure at ../misc/small_random_weights.vhd:150
in process .tb_ntru_prime_top(rtl).ntru_prime_top_inst@ntru_prime_top(rtl).small_random_weights_inst@small_random_weights(rtl).P0
./tb_ntru_prime_top:error: simulation failed
```